### PR TITLE
Fix canvas viewport centering and pan bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,120 @@
-# codex
+# iPad Annotation Suite
+
+フロントエンドとバックエンドで構成された、iPadOS + Apple Pencil 向けのフリーハンド領域注釈アプリです。画像データは大学サーバーなどのマウント済みストレージからバックエンド経由で配信され、フロントエンドは直接参照しません。
+
+## ディレクトリ構成
+
+```
+frontend/  # React + Vite + Konva ベースの UI
+server/    # Express + TypeScript バックエンド
+```
+
+## 前提
+
+- Node.js 18 以上
+- 大学サーバー上の画像ストレージを `/mnt/images` などにマウント済みであること
+- アノテーション JSON 保存用ディレクトリに書き込み権限があること
+
+## セットアップ
+
+### 共通
+
+1. リポジトリ直下で `.env` を作成し、サーバー設定を記述します。
+
+```bash
+cp server/.env.example server/.env
+# 必要に応じて編集
+```
+
+`IMAGE_ROOT` と `ANNOTATION_ROOT` を大学サーバーのマウントパスに合わせて変更してください。`~/mount/images` のようなチルダ表記もサポートされます。読み取り専用モードにしたい場合は `READ_ONLY=true` を指定します。画像拡張子を制限したい場合は `IMAGE_EXTENSIONS=jpg,png` のようにカンマ区切りで指定可能です（デフォルトは JPG/PNG/TIFF/BMP など一般的な形式）。
+
+### バックエンド
+
+```bash
+cd server
+npm install
+npm run dev
+```
+
+`http://localhost:4000/healthz` が `{ "ok": true }` を返せば起動完了です。
+
+### フロントエンド
+
+別ターミナルで:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Vite の開発サーバーが `http://localhost:5173` で立ち上がり、API リクエストはポート `4000` へプロキシされます。
+
+## トラブルシューティング
+
+### 画像が読み込まれない / 「画像がありません」と表示される
+
+1. バックエンドのログに `IMAGE_ROOT does not exist` が出ていないか確認してください。チルダ（`~/`）を含むパスや相対パスも `.env` 内で記述可能ですが、実際のマウントポイントと一致している必要があります。
+2. `IMAGE_EXTENSIONS` の設定を行った場合、対象の拡張子が含まれているかを確認してください。設定された拡張子以外は一覧に現れません。
+3. 画像がサブディレクトリにある場合でも、相対パスごと自動的に検出されます。大量のファイルを扱う場合は `limit` クエリでページングしてください（デフォルト 50、フロントエンドでは 100 を取得します）。
+4. ネットワークマウントの権限不足により `fs.access` が失敗した場合は、Node.js プロセスに対して読み取り権限が付与されているかを確認してください。
+
+### npm install で 403 Forbidden が返る
+
+キャンパスネットワークや CI 環境では、npm の公式レジストリへのアクセスが制限されている場合があります。`npm install` 実行時に
+`403 Forbidden` が発生する場合は以下を確認してください。
+
+1. 利用可能なレジストリ URL を設定する
+
+   大学が提供する社内レジストリがある場合はそちらを利用し、なければ npm 公式レジストリを明示します。
+
+   ```bash
+   npm config set registry https://registry.npmjs.org/
+   ```
+
+2. 認証が必要なレジストリではトークンを設定する
+
+   学内レジストリが Basic 認証やトークンを要求する場合は `.npmrc` に資格情報を追加します。
+
+   ```bash
+   npm config set //registry.example.ac.jp/:_authToken "<your-token>"
+   ```
+
+3. プロキシ経由が必要な場合
+
+   社内プロキシを経由する場合は以下を設定します。
+
+   ```bash
+   npm config set proxy http://proxy.example.ac.jp:8080
+   npm config set https-proxy http://proxy.example.ac.jp:8080
+   ```
+
+上記を設定したのち、`npm cache clean --force` を実行してから再度 `npm install` を試してください。
+
+## 動作ポイント
+
+- Konva を利用したレイヤー構成キャンバスで、Apple Pencil / タッチ操作を優先します。
+- ツールバーから色切替、レイヤー作成・切替、Undo/Redo 操作をすべて 1 画面で完結。
+- レイヤー／領域リストから該当オブジェクトへフォーカス可能。
+- Apple Pencil や指で自由に囲んだ領域のみ保存され、開放されたストロークは自動的に破棄されます。
+- 描画ごとに Undo/Redo 履歴が記録され、前の操作をすぐに取り消せます。
+- 次画像／前画像ボタンで移動すると同時に隣接画像をプリフェッチし、切替直後に描画できます。
+- アノテーションは画像単位の JSON で保存され、正規化座標 (0〜1) を使用。
+- `POST /api/annotations/:imageId` と `POST /api/annotations/:imageId/autosave` で原子的に保存し、再読み込み時に復元されます。
+
+## 簡易 E2E テスト手順
+
+1. バックエンドをローカルのモック画像で起動（`server/mock-data/images` に数枚の JPEG/PNG を配置してください）。
+2. フロントエンドを起動して `http://localhost:5173` を iPad Safari から開きます。
+3. Apple Pencil で領域を囲むように描画し、レイヤーを切り替えながら色を変更します。開始点と終了点がつながらないストロークは破棄されます。
+4. 「次へ」「前へ」で画像を切替え、プリフェッチが効いていることを確認します。
+5. ページをリロードして、直前に保存した注釈が再表示されることを確認します。
+6. バックエンドの `server/mock-data/annotations` に JSON が保存されていることを確認します。
+
+## CSV エクスポートについて
+
+サーバー側で注釈 JSON を読み込み、任意のバッチ処理で `image_id,layer,id,color,point_count,area,label` など必要な項目を CSV 化できます（領域座標は `points[{x,y}, ...]` として 0〜1 で格納されています）。将来的に専用エンドポイントを追加する場合は `AnnotationService` を拡張してください。
+
+## 認証ミドルウェア差し替え
+
+`server/src/middleware/auth.ts` の `attachAuth` を学内 SSO に合わせて差し替えることで、ユーザー情報を統一的に扱えます。実装は単純な関数なので、SSO トークン検証などを追加しても他の箇所への影響は最小限です。

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <title>Annotation App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "annotation-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "axios": "^1.6.7",
+    "konva": "^9.2.3",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-konva": "^18.2.10",
+    "zustand": "^4.5.2"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.28",
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.2.1",
+    "postcss": "^8.4.33",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.3.3",
+    "vite": "^5.1.0"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,424 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import axios from 'axios';
+import { useAnnotationStore } from './hooks/useAnnotationStore';
+import {
+  AnnotationDocument,
+  AnnotationLayer,
+  AnnotationShape,
+  ImageSummary,
+  NormalizedPoint,
+} from './types/annotations';
+import CanvasStage from './components/CanvasStage';
+import LayerPanel from './components/LayerPanel';
+import ColorPalette from './components/ColorPalette';
+import ImagePager from './components/ImagePager';
+import ShapeList from './components/ShapeList';
+
+const AUTOSAVE_INTERVAL = 15000;
+const FREEHAND_SAMPLES = 36;
+
+const clamp01 = (value: number) => Math.max(0, Math.min(1, value));
+
+const generateShapeId = () => `ann-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+const convertCircleToFreehand = (
+  shape: any,
+  docSize: { w: number; h: number }
+): AnnotationShape => {
+  const centerX = clamp01(Number(shape?.center?.x) || 0.5);
+  const centerY = clamp01(Number(shape?.center?.y) || 0.5);
+  const radiusNorm = typeof shape?.radius === 'number' ? shape.radius : 0.05;
+  const radiusPx = radiusNorm * docSize.w;
+  const points: NormalizedPoint[] = [];
+  for (let i = 0; i < FREEHAND_SAMPLES; i += 1) {
+    const angle = (2 * Math.PI * i) / FREEHAND_SAMPLES;
+    const px = centerX * docSize.w + Math.cos(angle) * radiusPx;
+    const py = centerY * docSize.h + Math.sin(angle) * radiusPx;
+    points.push({
+      x: clamp01(px / docSize.w),
+      y: clamp01(py / docSize.h),
+    });
+  }
+  const createdAt = shape?.created_at ?? new Date().toISOString();
+  return {
+    id: shape?.id ?? generateShapeId(),
+    type: 'freehand',
+    points,
+    color: shape?.color ?? '#FF3B30',
+    label: shape?.label ?? null,
+    created_at: createdAt,
+    updated_at: shape?.updated_at ?? createdAt,
+    closed: true,
+  };
+};
+
+const ensureFreehandShape = (
+  shape: any,
+  docSize: { w: number; h: number }
+): AnnotationShape => {
+  if (shape?.type === 'freehand' && Array.isArray(shape.points)) {
+    const sanitized = (shape.points as any[])
+      .map((pt) => ({
+        x: clamp01(Number(pt?.x) || 0),
+        y: clamp01(Number(pt?.y) || 0),
+      }))
+      .filter((pt, idx, arr) => idx === 0 || pt.x !== arr[idx - 1].x || pt.y !== arr[idx - 1].y);
+    if (sanitized.length >= 2) {
+      const createdAt = shape?.created_at ?? new Date().toISOString();
+      return {
+        id: shape?.id ?? generateShapeId(),
+        type: 'freehand',
+        points: sanitized,
+        color: shape?.color ?? '#FF3B30',
+        label: shape?.label ?? null,
+        created_at: createdAt,
+        updated_at: shape?.updated_at ?? createdAt,
+        closed: shape?.closed !== false,
+      };
+    }
+  }
+  return convertCircleToFreehand(shape, docSize);
+};
+
+const upgradeDocument = (image: ImageSummary, doc: AnnotationDocument): AnnotationDocument => {
+  const size = doc.image_size ?? { w: image.width, h: image.height };
+  const layers = doc.layers.map((layer, index) => {
+    const incomingLayer = layer as AnnotationLayer & { shapes: any[] };
+    return {
+      ...incomingLayer,
+      visible: incomingLayer.visible ?? true,
+      z: incomingLayer.z ?? index + 1,
+      shapes: (incomingLayer.shapes ?? []).map((shape: any) => ensureFreehandShape(shape, size)),
+    };
+  });
+  return { ...doc, image_size: size, layers };
+};
+
+const defaultDocument = (image: ImageSummary): AnnotationDocument => ({
+  image_id: image.id,
+  image_size: { w: image.width, h: image.height },
+  layers: [
+    {
+      id: `layer-${Date.now()}`,
+      name: 'default',
+      visible: true,
+      z: 1,
+      shapes: [],
+    },
+  ],
+  meta: {
+    device: 'iPadOS',
+    revision: 1,
+  },
+});
+
+function App() {
+  const store = useAnnotationStore();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const autosaveTimer = useRef<number>();
+  const toastTimer = useRef<number | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+  const [infoPanelOpen, setInfoPanelOpen] = useState(true);
+  const [resetViewportKey, setResetViewportKey] = useState(0);
+
+  useEffect(() => {
+    let mounted = true;
+    const fetchImages = async () => {
+      try {
+        const res = await axios.get<{ items: ImageSummary[]; nextCursor?: string }>(
+          '/api/images?limit=100'
+        );
+        if (!mounted) return;
+        store.setImages(res.data.items);
+        if (res.data.items.length > 0) {
+          await loadDocumentForIndex(0);
+        }
+      } catch (err) {
+        console.error(err);
+        setError('画像リストの取得に失敗しました');
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    };
+    void fetchImages();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (autosaveTimer.current) {
+      window.clearInterval(autosaveTimer.current);
+    }
+    autosaveTimer.current = window.setInterval(() => {
+      if (store.document && store.isDirty) {
+        void saveDocument(store.document, true);
+      }
+    }, AUTOSAVE_INTERVAL);
+    return () => {
+      if (autosaveTimer.current) {
+        window.clearInterval(autosaveTimer.current);
+      }
+    };
+  }, [store.document, store.isDirty]);
+
+  useEffect(() => {
+    return () => {
+      if (toastTimer.current) {
+        window.clearTimeout(toastTimer.current);
+      }
+    };
+  }, []);
+
+  const showToast = (message: string) => {
+    setToast(message);
+    if (toastTimer.current) {
+      window.clearTimeout(toastTimer.current);
+    }
+    toastTimer.current = window.setTimeout(() => setToast(null), 3000);
+  };
+
+  const loadDocumentForIndex = async (index: number) => {
+    const image = store.images[index];
+    if (!image) return;
+    setLoading(true);
+    try {
+      store.setCurrentImageIndex(index);
+      const res = await axios.get<AnnotationDocument | null>(`/api/annotations/${image.id}`);
+      const doc = upgradeDocument(image, res.data ?? defaultDocument(image));
+      store.setDocument(doc);
+      store.selectShape(doc.layers[0]?.id ?? null, null);
+      store.markDirty(false);
+      prefetchNeighbors(index);
+      await prefetchImage(image.id);
+    } catch (err) {
+      console.error(err);
+      setError('アノテーションデータの読み込みに失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const saveDocument = async (doc: AnnotationDocument, isAutosave = false) => {
+    try {
+      const target = isAutosave ? `/api/annotations/${doc.image_id}/autosave` : `/api/annotations/${doc.image_id}`;
+      await axios.post(target, doc);
+      if (!isAutosave) {
+        showToast('保存しました');
+      }
+      store.markDirty(false);
+    } catch (err) {
+      console.error(err);
+      if (!isAutosave) {
+        setError('保存に失敗しました');
+      }
+    }
+  };
+
+  const prefetchImage = async (imageId: string) => {
+    try {
+      const img = new Image();
+      img.src = `/api/images/${imageId}`;
+      await img.decode().catch(() => undefined);
+    } catch (err) {
+      console.warn('prefetch failed', err);
+    }
+  };
+
+  const prefetchNeighbors = (index: number) => {
+    const prev = store.images[index - 1];
+    const next = store.images[index + 1];
+    if (prev) void prefetchImage(prev.id);
+    if (next) void prefetchImage(next.id);
+  };
+
+  const onNext = () => {
+    const nextIndex = store.currentImageIndex + 1;
+    if (nextIndex < store.images.length) {
+      void loadDocumentForIndex(nextIndex);
+    }
+  };
+
+  const onPrev = () => {
+    const prevIndex = store.currentImageIndex - 1;
+    if (prevIndex >= 0) {
+      void loadDocumentForIndex(prevIndex);
+    }
+  };
+
+  const currentImage = useMemo(
+    () => store.images[store.currentImageIndex],
+    [store.images, store.currentImageIndex]
+  );
+
+  const currentLayer: AnnotationLayer | undefined = useMemo(() => {
+    if (!store.document) return undefined;
+    return store.document.layers.find((l) => l.id === store.selectedLayerId) ?? store.document.layers[0];
+  }, [store.document, store.selectedLayerId]);
+
+  if (loading && !store.document) {
+    return <div className="app-shell">読み込み中...</div>;
+  }
+
+  if (error) {
+    return <div className="app-shell">{error}</div>;
+  }
+
+  if (!store.document || !currentImage) {
+    return <div className="app-shell">画像がありません</div>;
+  }
+
+  return (
+    <div className="app-shell">
+      <div className="toolbar" role="toolbar">
+        <div className="toolbar-row">
+          <div className="toolbar-group">
+            <span>
+              {store.currentImageIndex + 1}/{store.images.length} : {currentImage.name}
+            </span>
+          </div>
+          <div className="toolbar-group pager-group">
+            <ImagePager
+              onPrev={onPrev}
+              onNext={onNext}
+              hasPrev={store.currentImageIndex > 0}
+              hasNext={store.currentImageIndex < store.images.length - 1}
+            />
+          </div>
+        </div>
+        <div className="toolbar-row wrap">
+          <div className="toolbar-group">
+            <ColorPalette
+              colors={store.palette}
+              selectedColor={store.drawingColor}
+              onColorChange={(color) => store.setDrawingColor(color)}
+              onPaletteChange={store.setPalette}
+            />
+          </div>
+          <div className="toolbar-group">
+            <label className="layer-select">
+              <span>アクティブレイヤー</span>
+              <select
+                value={currentLayer?.id ?? ''}
+                onChange={(e) => store.selectShape(e.target.value, null)}
+              >
+                {store.document.layers.map((layer) => (
+                  <option key={layer.id} value={layer.id}>
+                    {layer.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <button
+              className="control-button"
+              onClick={() => {
+                const newLayer: AnnotationLayer = {
+                  id: `layer-${Date.now()}`,
+                  name: `Layer ${store.document.layers.length + 1}`,
+                  visible: true,
+                  z: store.document.layers.length + 1,
+                  shapes: [],
+                };
+                store.addLayer(newLayer);
+              }}
+            >
+              レイヤー追加
+            </button>
+          </div>
+          <div className="toolbar-group">
+            <button
+              className={`control-button ${store.tool === 'draw' ? 'active' : ''}`}
+              onClick={() => store.setTool('draw')}
+            >
+              描画
+            </button>
+            <button
+              className={`control-button ${store.tool === 'select' ? 'active' : ''}`}
+              onClick={() => store.setTool('select')}
+            >
+              選択
+            </button>
+            <button
+              className={`control-button ${store.tool === 'pan' ? 'active' : ''}`}
+              onClick={() => store.setTool('pan')}
+            >
+              パン
+            </button>
+          </div>
+          <div className="toolbar-group">
+            <button className="control-button" onClick={() => store.undo()} disabled={!store.canUndo}>
+              Undo
+            </button>
+            <button className="control-button" onClick={() => store.redo()} disabled={!store.canRedo}>
+              Redo
+            </button>
+            <button className="control-button" onClick={() => setResetViewportKey((v) => v + 1)}>
+              ズームリセット
+            </button>
+            <button className="control-button" onClick={() => saveDocument(store.document!)}>
+              保存
+            </button>
+            <button className="control-button" onClick={() => setInfoPanelOpen((v) => !v)}>
+              {infoPanelOpen ? '情報パネルを閉じる' : '情報パネルを開く'}
+            </button>
+          </div>
+        </div>
+      </div>
+      <div className="workspace">
+        <div className="canvas-container">
+          <CanvasStage
+            key={store.document.image_id}
+            imageId={store.document.image_id}
+            imageSize={store.document.image_size}
+            layers={store.document.layers}
+            activeLayerId={currentLayer?.id ?? null}
+            drawingColor={store.drawingColor}
+            tool={store.tool}
+            selectedLayerId={store.selectedLayerId}
+            selectedShapeId={store.selectedShapeId}
+            resetViewportKey={resetViewportKey}
+            onAddShape={(layerId, shape) => store.addShape(layerId, shape)}
+            onUpdateShape={(layerId, shape) => store.updateShape(layerId, shape)}
+            onSelect={(layerId, shapeId) => store.selectShape(layerId, shapeId)}
+            onDeleteShape={(layerId, shapeId) => store.deleteShape(layerId, shapeId)}
+            onShapeRejected={showToast}
+          />
+          {toast && <div className="toast">{toast}</div>}
+        </div>
+        {infoPanelOpen && (
+          <div className="info-panel">
+            <LayerPanel
+              layers={store.document.layers}
+              selectedLayerId={currentLayer?.id ?? null}
+              onToggleVisibility={(layerId) => {
+                const layer = store.document.layers.find((l) => l.id === layerId);
+                if (!layer) return;
+                store.updateLayer({ ...layer, visible: !layer.visible });
+              }}
+              onToggleLock={(layerId) => {
+                const layer = store.document.layers.find((l) => l.id === layerId);
+                if (!layer) return;
+                store.updateLayer({ ...layer, locked: !layer.locked });
+              }}
+              onRename={(layerId, name) => {
+                const layer = store.document.layers.find((l) => l.id === layerId);
+                if (!layer) return;
+                store.updateLayer({ ...layer, name });
+              }}
+              onDelete={(layerId) => store.removeLayer(layerId)}
+            />
+            <ShapeList
+              layers={store.document.layers}
+              selectedLayerId={store.selectedLayerId}
+              selectedShapeId={store.selectedShapeId}
+              onSelect={(layerId, shapeId) => store.selectShape(layerId, shapeId)}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/components/CanvasStage.tsx
+++ b/frontend/src/components/CanvasStage.tsx
@@ -1,0 +1,423 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Stage, Layer as KonvaLayer, Line, Image as KonvaImage } from 'react-konva';
+import type Konva from 'konva';
+import { AnnotationLayer, AnnotationShape, NormalizedPoint } from '../types/annotations';
+import { ToolMode } from '../hooks/useAnnotationStore';
+
+interface CanvasStageProps {
+  imageId: string;
+  imageSize: { w: number; h: number };
+  layers: AnnotationLayer[];
+  activeLayerId: string | null;
+  drawingColor: string;
+  tool: ToolMode;
+  selectedLayerId: string | null;
+  selectedShapeId: string | null;
+  resetViewportKey: number;
+  onAddShape: (layerId: string, shape: AnnotationShape) => void;
+  onUpdateShape: (layerId: string, shape: AnnotationShape) => void;
+  onSelect: (layerId: string | null, shapeId: string | null) => void;
+  onDeleteShape: (layerId: string, shapeId: string) => void;
+  onShapeRejected?: (reason: string) => void;
+}
+
+const CanvasStage = ({
+  imageId,
+  imageSize,
+  layers,
+  activeLayerId,
+  drawingColor,
+  tool,
+  selectedLayerId,
+  selectedShapeId,
+  resetViewportKey,
+  onAddShape,
+  onUpdateShape,
+  onSelect,
+  onDeleteShape,
+  onShapeRejected,
+}: CanvasStageProps) => {
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const stageRef = useRef<Konva.Stage>(null);
+  const [stageScale, setStageScale] = useState(1);
+  const [stagePosition, setStagePosition] = useState({ x: 0, y: 0 });
+  const [containerSize, setContainerSize] = useState({ width: 0, height: 0 });
+  const [imageNode, setImageNode] = useState<HTMLImageElement | null>(null);
+  const [draftPath, setDraftPath] = useState<{ points: { x: number; y: number }[] } | null>(null);
+  const [isGesturePan, setIsGesturePan] = useState(false);
+
+  useEffect(() => {
+    if (!wrapperRef.current) return;
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      const { width, height } = entry.contentRect;
+      setContainerSize({ width, height });
+    });
+    observer.observe(wrapperRef.current);
+    return () => observer.disconnect();
+  }, []);
+
+  const clampStagePosition = useCallback(
+    (pos: { x: number; y: number }, scale = stageScale) => {
+      if (!containerSize.width || !containerSize.height) {
+        return pos;
+      }
+      const scaledWidth = imageSize.w * scale;
+      const scaledHeight = imageSize.h * scale;
+
+      const availableX = containerSize.width - scaledWidth;
+      const availableY = containerSize.height - scaledHeight;
+
+      const x = availableX >= 0
+        ? availableX / 2
+        : Math.min(0, Math.max(availableX, pos.x));
+      const y = availableY >= 0
+        ? availableY / 2
+        : Math.min(0, Math.max(availableY, pos.y));
+
+      return { x, y };
+    },
+    [containerSize.width, containerSize.height, imageSize.w, imageSize.h, stageScale]
+  );
+
+  useEffect(() => {
+    if (!containerSize.width || !containerSize.height) return;
+    const scale = Math.min(
+      containerSize.width / imageSize.w,
+      containerSize.height / imageSize.h
+    );
+    setStageScale(scale);
+    setStagePosition(
+      clampStagePosition(
+        {
+          x: (containerSize.width - imageSize.w * scale) / 2,
+          y: (containerSize.height - imageSize.h * scale) / 2,
+        },
+        scale
+      )
+    );
+  }, [clampStagePosition, containerSize.height, containerSize.width, imageSize.h, imageSize.w, resetViewportKey]);
+
+  useEffect(() => {
+    setStagePosition((prev) => clampStagePosition(prev));
+  }, [clampStagePosition, stageScale]);
+
+  useEffect(() => {
+    const img = new window.Image();
+    img.crossOrigin = 'anonymous';
+    img.src = `/api/images/${imageId}`;
+    img.onload = () => setImageNode(img);
+  }, [imageId]);
+
+  useEffect(() => {
+    setDraftPath(null);
+  }, [imageId]);
+
+  const handleWheel = useCallback(
+    (e: Konva.KonvaEventObject<WheelEvent>) => {
+      e.evt.preventDefault();
+      const stage = stageRef.current;
+      if (!stage) return;
+      const oldScale = stageScale;
+      const pointer = stage.getPointerPosition();
+      if (!pointer) return;
+      const scaleBy = 1.05;
+      const direction = e.evt.deltaY > 0 ? -1 : 1;
+      const newScale = direction > 0 ? oldScale * scaleBy : oldScale / scaleBy;
+      const nextScale = Math.max(0.05, Math.min(newScale, 8));
+      const mousePointTo = {
+        x: (pointer.x - stage.x()) / oldScale,
+        y: (pointer.y - stage.y()) / oldScale,
+      };
+      setStageScale(nextScale);
+      const newPos = {
+        x: pointer.x - mousePointTo.x * nextScale,
+        y: pointer.y - mousePointTo.y * nextScale,
+      };
+      setStagePosition(clampStagePosition(newPos, nextScale));
+    },
+    [clampStagePosition, stageScale]
+  );
+
+  useEffect(() => {
+    const stage = stageRef.current;
+    if (!stage) return;
+    stage.on('wheel', handleWheel as any);
+    return () => {
+      stage.off('wheel', handleWheel as any);
+    };
+  }, [handleWheel]);
+
+  const normalize = useCallback(
+    (point: { x: number; y: number }): NormalizedPoint => ({
+      x: Math.max(0, Math.min(1, point.x / imageSize.w)),
+      y: Math.max(0, Math.min(1, point.y / imageSize.h)),
+    }),
+    [imageSize]
+  );
+
+  const denormalize = useCallback(
+    (point: NormalizedPoint) => ({
+      x: point.x * imageSize.w,
+      y: point.y * imageSize.h,
+    }),
+    [imageSize]
+  );
+
+  const toImageCoords = useCallback(
+    (stagePoint: { x: number; y: number }) => {
+      return {
+        x: (stagePoint.x - stagePosition.x) / stageScale,
+        y: (stagePoint.y - stagePosition.y) / stageScale,
+      };
+    },
+    [stagePosition, stageScale]
+  );
+
+  const clampToImage = useCallback(
+    (point: { x: number; y: number }) => ({
+      x: Math.max(0, Math.min(imageSize.w, point.x)),
+      y: Math.max(0, Math.min(imageSize.h, point.y)),
+    }),
+    [imageSize]
+  );
+
+  const getActiveLayer = () => {
+    if (!layers.length) return undefined;
+    const layer = layers.find((l) => l.id === (activeLayerId ?? selectedLayerId ?? l.id));
+    return layer ?? layers[0];
+  };
+
+  const handlePointerDown = (evt: Konva.KonvaEventObject<PointerEvent>) => {
+    evt.evt.preventDefault();
+    const pointerType = evt.evt.pointerType;
+    if (pointerType === 'touch' && evt.evt.touches && evt.evt.touches.length > 1) {
+      setIsGesturePan(true);
+      return;
+    }
+    const stage = stageRef.current;
+    const pointer = stage?.getPointerPosition();
+    if (!pointer) return;
+    if (tool === 'draw') {
+      const activeLayer = getActiveLayer();
+      if (!activeLayer) return;
+      if (activeLayer.locked) {
+        onShapeRejected?.('ロックされたレイヤーには描画できません');
+        return;
+      }
+      onSelect(activeLayer.id, null);
+      const pos = clampToImage(toImageCoords(pointer));
+      setDraftPath({ points: [pos] });
+    } else if (tool === 'select') {
+      if (evt.target === stage) {
+        onSelect(null, null);
+      }
+    }
+  };
+
+  const handlePointerMove = (evt: Konva.KonvaEventObject<PointerEvent>) => {
+    if (!draftPath) return;
+    const stage = stageRef.current;
+    const pointer = stage?.getPointerPosition();
+    if (!pointer) return;
+    const pos = clampToImage(toImageCoords(pointer));
+    setDraftPath((prev) => {
+      if (!prev) return prev;
+      const lastPoint = prev.points[prev.points.length - 1];
+      const distance = Math.hypot(pos.x - lastPoint.x, pos.y - lastPoint.y);
+      if (distance < MIN_POINT_DISTANCE) {
+        return prev;
+      }
+      return { points: [...prev.points, pos] };
+    });
+  };
+
+  const polygonArea = (points: NormalizedPoint[]) => {
+    if (points.length < 3) return 0;
+    let area = 0;
+    for (let i = 0; i < points.length; i += 1) {
+      const current = points[i];
+      const next = points[(i + 1) % points.length];
+      area += current.x * next.y - next.x * current.y;
+    }
+    return Math.abs(area) / 2;
+  };
+
+  const finalizeDraft = () => {
+    if (!draftPath) return;
+    const layer = getActiveLayer();
+    if (!layer) {
+      setDraftPath(null);
+      return;
+    }
+    const points = draftPath.points;
+    if (points.length < 3) {
+      setDraftPath(null);
+      return;
+    }
+    const first = points[0];
+    const last = points[points.length - 1];
+    const distance = Math.hypot(last.x - first.x, last.y - first.y);
+    if (distance > CLOSE_THRESHOLD) {
+      setDraftPath(null);
+      onShapeRejected?.('始点と終点が閉じていないため図形を作成できませんでした');
+      return;
+    }
+    const normalizedPoints = points.map(normalize);
+    const area = polygonArea(normalizedPoints);
+    if (area < MIN_POLYGON_AREA) {
+      setDraftPath(null);
+      onShapeRejected?.('囲まれた面積が小さすぎるため無効化しました');
+      return;
+    }
+    const now = new Date().toISOString();
+    const shape: AnnotationShape = {
+      id: `ann-${Date.now()}`,
+      type: 'freehand',
+      points: normalizedPoints,
+      color: drawingColor,
+      label: null,
+      created_at: now,
+      updated_at: now,
+      closed: true,
+    };
+    onAddShape(layer.id, shape);
+    onSelect(layer.id, shape.id);
+    setDraftPath(null);
+  };
+
+  const handlePointerUp = () => {
+    setIsGesturePan(false);
+    finalizeDraft();
+  };
+
+  const handlePointerCancel = () => {
+    setIsGesturePan(false);
+    setDraftPath(null);
+  };
+
+  const handleDeleteSelected = useCallback(() => {
+    if (!selectedLayerId || !selectedShapeId) return;
+    onDeleteShape(selectedLayerId, selectedShapeId);
+    onSelect(selectedLayerId, null);
+  }, [onDeleteShape, onSelect, selectedLayerId, selectedShapeId]);
+
+  useEffect(() => {
+    const handler = (ev: KeyboardEvent) => {
+      if (ev.key === 'Delete' || ev.key === 'Backspace') {
+        handleDeleteSelected();
+      }
+      if ((ev.ctrlKey || ev.metaKey) && ev.key === '0') {
+        setStageScale(1);
+        setStagePosition({ x: 0, y: 0 });
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [handleDeleteSelected]);
+
+  const renderLayers = () =>
+    layers
+      .filter((layer) => layer.visible !== false)
+      .map((layer) => (
+        <KonvaLayer key={layer.id} listening={tool !== 'pan'}>
+          {layer.shapes.map((shape) => {
+            const points = shape.points
+              .map(denormalize)
+              .flatMap((pt) => [pt.x, pt.y]);
+            const isActive = layer.id === selectedLayerId && shape.id === selectedShapeId;
+            return (
+              <Line
+                key={shape.id}
+                points={points}
+                closed={shape.closed}
+                stroke={shape.color}
+                strokeWidth={isActive ? 6 / stageScale : 4 / stageScale}
+                fill={`${shape.color}22`}
+                opacity={layer.locked ? 0.6 : 1}
+                dash={layer.locked ? [12, 6] : undefined}
+                draggable={tool === 'select' && !layer.locked}
+                onClick={(e) => {
+                  e.cancelBubble = true;
+                  onSelect(layer.id, shape.id);
+                }}
+                onTap={(e) => {
+                  e.cancelBubble = true;
+                  onSelect(layer.id, shape.id);
+                }}
+                onDragEnd={(e) => {
+                  if (tool !== 'select' || layer.locked) return;
+                  const node = e.target as Konva.Line;
+                  const dx = node.x();
+                  const dy = node.y();
+                  const newPoints = [] as NormalizedPoint[];
+                  for (let i = 0; i < shape.points.length; i += 1) {
+                    const original = denormalize(shape.points[i]);
+                    const moved = clampToImage({ x: original.x + dx, y: original.y + dy });
+                    newPoints.push(normalize(moved));
+                  }
+                  node.x(0);
+                  node.y(0);
+                  const updated: AnnotationShape = {
+                    ...shape,
+                    points: newPoints,
+                    updated_at: new Date().toISOString(),
+                  };
+                  onUpdateShape(layer.id, updated);
+                }}
+                listening={tool !== 'pan'}
+              />
+            );
+          })}
+        </KonvaLayer>
+      ));
+
+  if (!containerSize.width || !containerSize.height) {
+    return <div className="stage-wrapper" ref={wrapperRef} />;
+  }
+
+  return (
+    <div className="stage-wrapper" ref={wrapperRef}>
+      <Stage
+        ref={stageRef}
+        width={containerSize.width}
+        height={containerSize.height}
+        scaleX={stageScale}
+        scaleY={stageScale}
+        x={stagePosition.x}
+        y={stagePosition.y}
+        draggable={tool === 'pan' || isGesturePan}
+        dragBoundFunc={(pos) => clampStagePosition(pos)}
+        onDragEnd={(e) => {
+          setStagePosition(clampStagePosition({ x: e.target.x(), y: e.target.y() }));
+        }}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerCancel}
+        style={{ touchAction: 'none', background: '#000' }}
+      >
+        <KonvaLayer listening={false}>
+          {imageNode && <KonvaImage image={imageNode} width={imageSize.w} height={imageSize.h} />}
+          {draftPath && (
+            <Line
+              points={draftPath.points.flatMap((pt) => [pt.x, pt.y])}
+              stroke={drawingColor}
+              strokeWidth={3 / stageScale}
+              dash={[10, 6]}
+              closed={false}
+            />
+          )}
+        </KonvaLayer>
+        {renderLayers()}
+      </Stage>
+    </div>
+  );
+};
+
+export default CanvasStage;
+
+const MIN_POINT_DISTANCE = 4;
+const CLOSE_THRESHOLD = 32;
+const MIN_POLYGON_AREA = 0.0002;

--- a/frontend/src/components/ColorPalette.tsx
+++ b/frontend/src/components/ColorPalette.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+
+interface ColorPaletteProps {
+  colors: string[];
+  selectedColor: string;
+  onColorChange: (color: string) => void;
+  onPaletteChange: (palette: string[]) => void;
+}
+
+const ColorPalette = ({ colors, selectedColor, onColorChange, onPaletteChange }: ColorPaletteProps) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [draftColor, setDraftColor] = useState(selectedColor);
+
+  return (
+    <div className="palette" onPointerDown={(e) => e.stopPropagation()}>
+      {colors.map((color) => (
+        <button
+          key={color}
+          className={color === selectedColor ? 'active' : ''}
+          onClick={() => onColorChange(color)}
+          onPointerDown={(e) => {
+            if ((e as PointerEvent).pointerType === 'pen') {
+              e.currentTarget.setPointerCapture(e.pointerId);
+            }
+          }}
+          onContextMenu={(e) => {
+            e.preventDefault();
+            setDraftColor(color);
+            setIsEditing(true);
+          }}
+          onPointerUp={(e) => {
+            if ((e as PointerEvent).pointerType === 'pen') {
+              e.currentTarget.releasePointerCapture(e.pointerId);
+            }
+          }}
+        >
+          <span style={{ background: color }} />
+        </button>
+      ))}
+      {isEditing && (
+        <div style={{ position: 'absolute', background: '#fff', padding: 12, borderRadius: 12, boxShadow: '0 12px 24px rgba(0,0,0,0.2)' }}>
+          <input
+            type="color"
+            value={draftColor}
+            onChange={(e) => setDraftColor(e.target.value)}
+          />
+          <button
+            className="control-button"
+            onClick={() => {
+              const newPalette = colors.map((color) => (color === selectedColor ? draftColor : color));
+              onPaletteChange(newPalette);
+              onColorChange(draftColor);
+              setIsEditing(false);
+            }}
+          >
+            更新
+          </button>
+          <button className="control-button" onClick={() => setIsEditing(false)}>
+            キャンセル
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ColorPalette;

--- a/frontend/src/components/ImagePager.tsx
+++ b/frontend/src/components/ImagePager.tsx
@@ -1,0 +1,21 @@
+interface ImagePagerProps {
+  onPrev: () => void;
+  onNext: () => void;
+  hasPrev: boolean;
+  hasNext: boolean;
+}
+
+const ImagePager = ({ onPrev, onNext, hasPrev, hasNext }: ImagePagerProps) => {
+  return (
+    <div style={{ display: 'flex', gap: 8 }}>
+      <button className="control-button" onClick={onPrev} disabled={!hasPrev}>
+        前へ
+      </button>
+      <button className="control-button" onClick={onNext} disabled={!hasNext}>
+        次へ
+      </button>
+    </div>
+  );
+};
+
+export default ImagePager;

--- a/frontend/src/components/LayerPanel.tsx
+++ b/frontend/src/components/LayerPanel.tsx
@@ -1,0 +1,54 @@
+import { AnnotationLayer } from '../types/annotations';
+
+interface LayerPanelProps {
+  layers: AnnotationLayer[];
+  selectedLayerId: string | null;
+  onToggleVisibility: (layerId: string) => void;
+  onToggleLock: (layerId: string) => void;
+  onRename: (layerId: string, name: string) => void;
+  onDelete: (layerId: string) => void;
+}
+
+const LayerPanel = ({
+  layers,
+  selectedLayerId,
+  onToggleVisibility,
+  onToggleLock,
+  onRename,
+  onDelete,
+}: LayerPanelProps) => {
+  return (
+    <div className="layer-panel">
+      <h3>レイヤー</h3>
+      {layers.map((layer) => (
+        <div key={layer.id} className="layer-item">
+          <div style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
+            <input
+              type="text"
+              value={layer.name}
+              onChange={(e) => onRename(layer.id, e.target.value)}
+              style={{ border: '1px solid rgba(0,0,0,0.1)', borderRadius: 6, padding: '4px 8px' }}
+            />
+            <small>図形: {layer.shapes.length}</small>
+          </div>
+          <button className="control-button" onClick={() => onToggleVisibility(layer.id)}>
+            {layer.visible ? '表示' : '非表示'}
+          </button>
+          <button className="control-button" onClick={() => onToggleLock(layer.id)}>
+            {layer.locked ? 'ロック' : '解除'}
+          </button>
+          <button
+            className="control-button"
+            onClick={() => onDelete(layer.id)}
+            disabled={layers.length <= 1}
+            style={{ background: layer.id === selectedLayerId ? '#ffd1d1' : undefined }}
+          >
+            削除
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default LayerPanel;

--- a/frontend/src/components/ShapeList.tsx
+++ b/frontend/src/components/ShapeList.tsx
@@ -1,0 +1,55 @@
+import { AnnotationLayer, AnnotationShape } from '../types/annotations';
+
+interface ShapeListProps {
+  layers: AnnotationLayer[];
+  selectedLayerId: string | null;
+  selectedShapeId: string | null;
+  onSelect: (layerId: string, shapeId: string) => void;
+}
+
+const ShapeList = ({ layers, selectedLayerId, selectedShapeId, onSelect }: ShapeListProps) => {
+  const areaOf = (shape: AnnotationShape) => {
+    if (shape.points.length < 3) return 0;
+    let area = 0;
+    for (let i = 0; i < shape.points.length; i += 1) {
+      const current = shape.points[i];
+      const next = shape.points[(i + 1) % shape.points.length];
+      area += current.x * next.y - next.x * current.y;
+    }
+    return Math.abs(area) / 2;
+  };
+
+  return (
+    <div className="shape-list">
+      <h3>領域リスト</h3>
+      {layers.map((layer) => (
+        <div key={layer.id}>
+          <h4 style={{ marginBottom: 4 }}>{layer.name}</h4>
+          {layer.shapes.map((shape) => (
+            <div
+              key={shape.id}
+              className="shape-row"
+              style={{ background: shape.id === selectedShapeId ? '#e6f7ff' : undefined }}
+            >
+              <span>#{shape.id}</span>
+              <span style={{ display: 'inline-flex', flexDirection: 'column', gap: 2 }}>
+                <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                  <span style={{ width: 12, height: 12, borderRadius: '50%', background: shape.color }} />
+                  {shape.points.length} 点
+                </span>
+                <span style={{ fontSize: 12, color: '#666' }}>
+                  面積: {(areaOf(shape) * 100).toFixed(1)}%
+                </span>
+              </span>
+              <button className="control-button" onClick={() => onSelect(layer.id, shape.id)}>
+                フォーカス
+              </button>
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ShapeList;

--- a/frontend/src/hooks/useAnnotationStore.ts
+++ b/frontend/src/hooks/useAnnotationStore.ts
@@ -1,0 +1,252 @@
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+import {
+  AnnotationDocument,
+  AnnotationLayer,
+  AnnotationShape,
+  ImageSummary,
+} from '../types/annotations';
+
+const cloneDocument = (doc: AnnotationDocument): AnnotationDocument => {
+  const globalClone = (globalThis as { structuredClone?: <T>(value: T) => T }).structuredClone;
+  if (typeof globalClone === 'function') {
+    return globalClone(doc);
+  }
+  return JSON.parse(JSON.stringify(doc));
+};
+
+export type ToolMode = 'draw' | 'select' | 'pan';
+
+export interface AnnotationState {
+  document: AnnotationDocument | null;
+  images: ImageSummary[];
+  currentImageIndex: number;
+  tool: ToolMode;
+  drawingColor: string;
+  palette: string[];
+  selectedLayerId: string | null;
+  selectedShapeId: string | null;
+  isDirty: boolean;
+  history: AnnotationDocument[];
+  future: AnnotationDocument[];
+  canUndo: boolean;
+  canRedo: boolean;
+  setDocument: (doc: AnnotationDocument | null) => void;
+  setImages: (items: ImageSummary[]) => void;
+  setCurrentImageIndex: (index: number) => void;
+  setTool: (tool: ToolMode) => void;
+  setDrawingColor: (color: string) => void;
+  setPalette: (colors: string[]) => void;
+  ensureLayer: (name?: string) => AnnotationLayer;
+  addLayer: (layer: AnnotationLayer) => void;
+  updateLayer: (layer: AnnotationLayer) => void;
+  removeLayer: (layerId: string) => void;
+  addShape: (layerId: string, shape: AnnotationShape) => void;
+  updateShape: (layerId: string, shape: AnnotationShape) => void;
+  deleteShape: (layerId: string, shapeId: string) => void;
+  selectShape: (layerId: string | null, shapeId: string | null) => void;
+  markDirty: (dirty: boolean) => void;
+  undo: () => void;
+  redo: () => void;
+}
+
+const defaultPalette = ['#FF3B30', '#34C759', '#007AFF', '#FF9500', '#AF52DE', '#5AC8FA', '#FFCC00'];
+
+export const useAnnotationStore = create<AnnotationState>()(
+  devtools((set, get) => ({
+    document: null,
+    images: [],
+    currentImageIndex: 0,
+    tool: 'draw',
+    drawingColor: defaultPalette[0],
+    palette: defaultPalette,
+    selectedLayerId: null,
+    selectedShapeId: null,
+    isDirty: false,
+    history: [],
+    future: [],
+    canUndo: false,
+    canRedo: false,
+    setDocument: (document) =>
+      set({
+        document,
+        history: [],
+        future: [],
+        canUndo: false,
+        canRedo: false,
+        selectedLayerId: document?.layers[0]?.id ?? null,
+        selectedShapeId: null,
+        isDirty: false,
+      }),
+    setImages: (images) => set({ images }),
+    setCurrentImageIndex: (currentImageIndex) => set({ currentImageIndex }),
+    setTool: (tool) => set({ tool }),
+    setDrawingColor: (drawingColor) => set({ drawingColor }),
+    setPalette: (palette) => set({ palette }),
+    ensureLayer: (name = 'layer') => {
+      const { document, addLayer } = get();
+      if (!document) {
+        throw new Error('Document not loaded');
+      }
+      if (document.layers.length === 0) {
+        const layer: AnnotationLayer = {
+          id: `layer-${Date.now()}`,
+          name,
+          visible: true,
+          z: 1,
+          shapes: [],
+        };
+        addLayer(layer);
+        return layer;
+      }
+      const { selectedLayerId } = get();
+      const active = document.layers.find((l) => l.id === selectedLayerId && !l.locked);
+      if (active) {
+        return active;
+      }
+      return document.layers[0];
+    },
+    addLayer: (layer) =>
+      set((state) => {
+        if (!state.document) return state;
+        const history = [...state.history, cloneDocument(state.document)];
+        const layers = [...state.document.layers, layer].sort((a, b) => a.z - b.z);
+        return {
+          document: { ...state.document, layers },
+          selectedLayerId: layer.id,
+          isDirty: true,
+          history,
+          future: [],
+          canUndo: history.length > 0,
+          canRedo: false,
+        };
+      }),
+    updateLayer: (layer) =>
+      set((state) => {
+        if (!state.document) return state;
+        const history = [...state.history, cloneDocument(state.document)];
+        const layers = state.document.layers.map((l) => (l.id === layer.id ? layer : l));
+        return {
+          document: { ...state.document, layers },
+          isDirty: true,
+          history,
+          future: [],
+          canUndo: history.length > 0,
+          canRedo: false,
+        };
+      }),
+    removeLayer: (layerId) =>
+      set((state) => {
+        if (!state.document) return state;
+        const history = [...state.history, cloneDocument(state.document)];
+        const layers = state.document.layers.filter((l) => l.id !== layerId);
+        return {
+          document: { ...state.document, layers },
+          selectedLayerId: layers[0]?.id ?? null,
+          isDirty: true,
+          history,
+          future: [],
+          canUndo: history.length > 0,
+          canRedo: false,
+        };
+      }),
+    addShape: (layerId, shape) =>
+      set((state) => {
+        if (!state.document) return state;
+        const history = [...state.history, cloneDocument(state.document)];
+        const layers = state.document.layers.map((layer) =>
+          layer.id === layerId
+            ? { ...layer, shapes: [...layer.shapes, shape] }
+            : layer
+        );
+        return {
+          document: { ...state.document, layers },
+          selectedLayerId: layerId,
+          selectedShapeId: shape.id,
+          isDirty: true,
+          history,
+          future: [],
+          canUndo: history.length > 0,
+          canRedo: false,
+        };
+      }),
+    updateShape: (layerId, shape) =>
+      set((state) => {
+        if (!state.document) return state;
+        const history = [...state.history, cloneDocument(state.document)];
+        const layers = state.document.layers.map((layer) =>
+          layer.id === layerId
+            ? {
+                ...layer,
+                shapes: layer.shapes.map((s) => (s.id === shape.id ? shape : s)),
+              }
+            : layer
+        );
+        return {
+          document: { ...state.document, layers },
+          isDirty: true,
+          history,
+          future: [],
+          canUndo: history.length > 0,
+          canRedo: false,
+        };
+      }),
+    deleteShape: (layerId, shapeId) =>
+      set((state) => {
+        if (!state.document) return state;
+        const history = [...state.history, cloneDocument(state.document)];
+        const layers = state.document.layers.map((layer) =>
+          layer.id === layerId
+            ? {
+                ...layer,
+                shapes: layer.shapes.filter((shape) => shape.id !== shapeId),
+              }
+            : layer
+        );
+        return {
+          document: { ...state.document, layers },
+          selectedShapeId: null,
+          isDirty: true,
+          history,
+          future: [],
+          canUndo: history.length > 0,
+          canRedo: false,
+        };
+      }),
+    selectShape: (layerId, shapeId) => set({ selectedLayerId: layerId, selectedShapeId: shapeId }),
+    markDirty: (dirty) => set({ isDirty: dirty }),
+    undo: () =>
+      set((state) => {
+        if (!state.document || state.history.length === 0) return state;
+        const previous = state.history[state.history.length - 1];
+        const history = state.history.slice(0, -1);
+        const future = [cloneDocument(state.document), ...state.future];
+        return {
+          document: cloneDocument(previous),
+          history,
+          future,
+          canUndo: history.length > 0,
+          canRedo: true,
+          selectedLayerId: previous.layers[0]?.id ?? null,
+          selectedShapeId: null,
+          isDirty: true,
+        };
+      }),
+    redo: () =>
+      set((state) => {
+        if (!state.document || state.future.length === 0) return state;
+        const [next, ...rest] = state.future;
+        const history = [...state.history, cloneDocument(state.document)];
+        return {
+          document: cloneDocument(next),
+          history,
+          future: rest,
+          canUndo: history.length > 0,
+          canRedo: rest.length > 0,
+          selectedLayerId: next.layers[0]?.id ?? null,
+          selectedShapeId: null,
+          isDirty: true,
+        };
+      }),
+  }))
+);

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles/global.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,0 +1,206 @@
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #111;
+  background-color: #f7f7f7;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html, body, #root {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  overscroll-behavior: contain;
+  touch-action: manipulation;
+}
+
+body {
+  -webkit-font-smoothing: antialiased;
+}
+
+button {
+  font: inherit;
+}
+
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.canvas-container {
+  flex: 1;
+  background: #111;
+  position: relative;
+  touch-action: none;
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px 16px;
+  background: #fff;
+  border-bottom: 1px solid rgba(0,0,0,0.1);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.toolbar-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.toolbar-row.wrap {
+  align-items: stretch;
+}
+
+.toolbar-group {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.layer-panel {
+  padding: 12px;
+}
+
+.layer-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 0;
+  border-bottom: 1px solid rgba(0,0,0,0.05);
+}
+
+.shape-list {
+  padding: 0 12px 24px 12px;
+}
+
+.shape-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 0;
+  border-bottom: 1px solid rgba(0,0,0,0.04);
+  font-size: 14px;
+}
+
+.workspace {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+}
+
+.info-panel {
+  width: 320px;
+  max-width: 35vw;
+  border-left: 1px solid rgba(0,0,0,0.1);
+  background: #fff;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.palette {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.palette button {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  background: transparent;
+  padding: 0;
+}
+
+.palette button.active {
+  border-color: #007aff;
+}
+
+.palette button span {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+}
+
+.control-button {
+  padding: 6px 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(0,0,0,0.1);
+  background: #fafafa;
+  cursor: pointer;
+}
+
+.control-button.active {
+  background: #007aff;
+  color: #fff;
+  border-color: #007aff;
+}
+
+.control-button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.control-button:active {
+  background: #e5e5ea;
+}
+
+.layer-select {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: #4a4a4a;
+}
+
+.layer-select select {
+  padding: 6px;
+  border-radius: 8px;
+  border: 1px solid rgba(0,0,0,0.1);
+  min-width: 160px;
+}
+
+.toast {
+  position: absolute;
+  left: 50%;
+  bottom: 24px;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.85);
+  color: #fff;
+  padding: 10px 18px;
+  border-radius: 999px;
+  font-size: 14px;
+  pointer-events: none;
+}
+
+.stage-wrapper {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  touch-action: none;
+  background: #000;
+}

--- a/frontend/src/types/annotations.ts
+++ b/frontend/src/types/annotations.ts
@@ -1,0 +1,44 @@
+export type NormalizedPoint = {
+  x: number;
+  y: number;
+};
+
+export type AnnotationFreehand = {
+  id: string;
+  type: 'freehand';
+  points: NormalizedPoint[];
+  color: string;
+  label: string | null;
+  created_at: string;
+  updated_at: string;
+  closed: boolean;
+};
+
+export type AnnotationShape = AnnotationFreehand;
+
+export type AnnotationLayer = {
+  id: string;
+  name: string;
+  visible: boolean;
+  z: number;
+  shapes: AnnotationShape[];
+  locked?: boolean;
+};
+
+export type AnnotationDocument = {
+  image_id: string;
+  image_size: { w: number; h: number };
+  layers: AnnotationLayer[];
+  meta: Record<string, unknown> & {
+    annotator?: string;
+    device?: string;
+    revision?: number;
+  };
+};
+
+export type ImageSummary = {
+  id: string;
+  name: string;
+  width: number;
+  height: number;
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": []
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    host: '0.0.0.0',
+    proxy: {
+      '/api': {
+        target: 'http://localhost:4000',
+        changeOrigin: true,
+        secure: false
+      }
+    }
+  }
+});

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,5 @@
+PORT=4000
+IMAGE_ROOT=./mock-data/images
+ANNOTATION_ROOT=./mock-data/annotations
+READ_ONLY=false
+# IMAGE_EXTENSIONS=jpg,jpeg,png,tif,tiff

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "annotation-server",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "axios": "^1.6.7",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "image-size": "^1.0.2",
+    "mime-types": "^2.1.35",
+    "morgan": "^1.10.0",
+    "multer": "^1.4.5-lts.1",
+    "pino": "^8.19.0",
+    "pino-pretty": "^10.2.0"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.11.28",
+    "@types/multer": "^1.4.7",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/server/src/adapters/fsAdapter.ts
+++ b/server/src/adapters/fsAdapter.ts
@@ -1,0 +1,159 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+export interface StorageAdapter {
+  listImages: (cursor?: string, limit?: number) => Promise<{ items: StorageImage[]; nextCursor?: string }>;
+  getImageStreamPath: (id: string) => Promise<string>;
+  readAnnotation: (id: string) => Promise<string | null>;
+  writeAnnotation: (id: string, body: string) => Promise<void>;
+  ensureReady: () => Promise<void>;
+}
+
+export interface StorageImage {
+  id: string;
+  name: string;
+  width: number;
+  height: number;
+  path: string;
+}
+
+export interface FsAdapterOptions {
+  imageRoot: string;
+  annotationRoot: string;
+  readOnly?: boolean;
+  imageExtensions?: string[];
+}
+
+const DEFAULT_IMAGE_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.webp', '.tif', '.tiff', '.bmp'];
+
+const normalizeExtension = (value: string) => {
+  const trimmed = value.trim().toLowerCase();
+  if (!trimmed) return null;
+  return trimmed.startsWith('.') ? trimmed : `.${trimmed}`;
+};
+
+async function readImageMetadata(filePath: string): Promise<{ width: number; height: number }> {
+  const buffer = await fs.readFile(filePath);
+  try {
+    const sizeOf = (await import('image-size')).imageSize;
+    const size = sizeOf(buffer);
+    if (!size.width || !size.height) {
+      throw new Error('Missing dimension');
+    }
+    return { width: size.width, height: size.height };
+  } catch (error) {
+    throw new Error(`Failed to read image metadata: ${(error as Error).message}`);
+  }
+}
+
+export const createFsAdapter = ({ imageRoot, annotationRoot, readOnly, imageExtensions }: FsAdapterOptions): StorageAdapter => {
+  const allowedExtensions = new Set(
+    (imageExtensions && imageExtensions.length > 0
+      ? imageExtensions
+      : DEFAULT_IMAGE_EXTENSIONS
+    )
+      .map(normalizeExtension)
+      .filter((ext): ext is string => Boolean(ext))
+  );
+
+  const resolveImagePath = (id: string) => path.join(imageRoot, id);
+  const resolveAnnotationPath = (id: string) => path.join(annotationRoot, `${id}.json`);
+
+  const ensureDir = async (dir: string) => {
+    await fs.mkdir(dir, { recursive: true });
+  };
+
+  const collectImageCandidates = async () => {
+    const results: string[] = [];
+    const queue: { absPath: string; relPath: string }[] = [{ absPath: imageRoot, relPath: '' }];
+    while (queue.length > 0) {
+      const { absPath, relPath } = queue.shift()!;
+      const entries = await fs.readdir(absPath, { withFileTypes: true });
+      for (const entry of entries) {
+        const entryRelPath = relPath ? path.join(relPath, entry.name) : entry.name;
+        const entryAbsPath = path.join(absPath, entry.name);
+        if (entry.isDirectory()) {
+          queue.push({ absPath: entryAbsPath, relPath: entryRelPath });
+          continue;
+        }
+        if (!entry.isFile()) {
+          continue;
+        }
+        const ext = path.extname(entry.name).toLowerCase();
+        if (allowedExtensions.size && !allowedExtensions.has(ext)) {
+          continue;
+        }
+        results.push(entryRelPath);
+      }
+    }
+    return results.sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+  };
+
+  return {
+    async ensureReady() {
+      try {
+        const stat = await fs.stat(imageRoot);
+        if (!stat.isDirectory()) {
+          throw new Error(`IMAGE_ROOT must point to a directory: ${imageRoot}`);
+        }
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+          throw new Error(`IMAGE_ROOT does not exist: ${imageRoot}`);
+        }
+        throw error;
+      }
+      await ensureDir(annotationRoot);
+    },
+    async listImages(cursor = '', limit = 50) {
+      const files = await collectImageCandidates();
+      if (files.length === 0) {
+        return { items: [], nextCursor: undefined };
+      }
+      let startIndex = 0;
+      if (cursor) {
+        const idx = files.indexOf(cursor);
+        startIndex = idx >= 0 ? idx + 1 : 0;
+      }
+      const slice = files.slice(startIndex, startIndex + limit);
+      const items: StorageImage[] = [];
+      for (const relativePath of slice) {
+        const filePath = resolveImagePath(relativePath);
+        try {
+          const { width, height } = await readImageMetadata(filePath);
+          items.push({ id: relativePath, name: path.basename(relativePath), width, height, path: filePath });
+        } catch (error) {
+          console.warn(`Skipping unreadable image: ${filePath}`, error);
+        }
+      }
+      const nextCursor = slice.length === limit ? slice[slice.length - 1] : undefined;
+      return { items, nextCursor };
+    },
+    async getImageStreamPath(id: string) {
+      const filePath = resolveImagePath(id);
+      await fs.access(filePath);
+      return filePath;
+    },
+    async readAnnotation(id: string) {
+      const annotationPath = resolveAnnotationPath(id);
+      try {
+        const body = await fs.readFile(annotationPath, 'utf-8');
+        return body;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+          return null;
+        }
+        throw error;
+      }
+    },
+    async writeAnnotation(id: string, body: string) {
+      if (readOnly) {
+        throw new Error('Storage adapter is read-only');
+      }
+      const annotationPath = resolveAnnotationPath(id);
+      await ensureDir(path.dirname(annotationPath));
+      const tmpPath = `${annotationPath}.tmp-${process.pid}`;
+      await fs.writeFile(tmpPath, body, 'utf-8');
+      await fs.rename(tmpPath, annotationPath);
+    },
+  };
+};

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,0 +1,67 @@
+import 'dotenv/config';
+import express from 'express';
+import morgan from 'morgan';
+import os from 'os';
+import path from 'path';
+import { createFsAdapter } from './adapters/fsAdapter';
+import { AnnotationService } from './services/annotationService';
+import { createImageRouter } from './routes/images';
+import { createAnnotationRouter } from './routes/annotations';
+import { attachAuth } from './middleware/auth';
+import { logger } from './utils/logger';
+
+const resolveUserPath = (inputPath: string) => {
+  if (inputPath.startsWith('~/')) {
+    return path.join(os.homedir(), inputPath.slice(2));
+  }
+  if (path.isAbsolute(inputPath)) {
+    return inputPath;
+  }
+  return path.resolve(process.cwd(), inputPath);
+};
+
+const PORT = Number(process.env.PORT ?? 4000);
+const IMAGE_ROOT = resolveUserPath(process.env.IMAGE_ROOT ?? path.resolve(process.cwd(), 'mock-data/images'));
+const ANNOTATION_ROOT = resolveUserPath(
+  process.env.ANNOTATION_ROOT ?? path.resolve(process.cwd(), 'mock-data/annotations')
+);
+const IMAGE_EXTENSIONS = process.env.IMAGE_EXTENSIONS?.split(',').map((ext) => ext.trim()).filter(Boolean);
+const READ_ONLY = process.env.READ_ONLY === 'true';
+
+async function bootstrap() {
+  const app = express();
+  const adapter = createFsAdapter({
+    imageRoot: IMAGE_ROOT,
+    annotationRoot: ANNOTATION_ROOT,
+    readOnly: READ_ONLY,
+    imageExtensions: IMAGE_EXTENSIONS,
+  });
+  await adapter.ensureReady();
+  const service = new AnnotationService(adapter);
+
+  app.disable('x-powered-by');
+  app.use(morgan('tiny'));
+  app.use(express.json({ limit: '5mb' }));
+  app.use(attachAuth);
+
+  app.get('/healthz', (_req, res) => {
+    res.json({ ok: true });
+  });
+
+  app.use('/api/images', createImageRouter(service));
+  app.use('/api/annotations', createAnnotationRouter(service));
+
+  app.use((err: any, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    logger.error({ err }, 'Unhandled error');
+    res.status(err.status || 500).json({ message: 'Internal Server Error' });
+  });
+
+  app.listen(PORT, () => {
+    logger.info({ port: PORT, imageRoot: IMAGE_ROOT, annotationRoot: ANNOTATION_ROOT }, 'server listening');
+  });
+}
+
+bootstrap().catch((error) => {
+  logger.error(error, 'Failed to start server');
+  process.exit(1);
+});

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -1,0 +1,24 @@
+import { Request, Response, NextFunction } from 'express';
+
+export interface AuthContext {
+  userId: string;
+  roles: string[];
+}
+
+declare module 'express-serve-static-core' {
+  interface Request {
+    auth?: AuthContext;
+  }
+}
+
+/**
+ * Dummy authentication middleware that can be swapped with campus SSO.
+ * Attaches a static user context for downstream auditing without leaking credentials.
+ */
+export const attachAuth = (req: Request, _res: Response, next: NextFunction) => {
+  req.auth = {
+    userId: 'demo-user',
+    roles: ['annotator'],
+  };
+  next();
+};

--- a/server/src/routes/annotations.ts
+++ b/server/src/routes/annotations.ts
@@ -1,0 +1,40 @@
+import { Router } from 'express';
+import { AnnotationService } from '../services/annotationService';
+import { logger } from '../utils/logger';
+
+export const createAnnotationRouter = (service: AnnotationService) => {
+  const router = Router();
+
+  router.get('/:imageId', async (req, res, next) => {
+    try {
+      const data = await service.getAnnotation(req.params.imageId);
+      if (!data) {
+        res.json(null);
+      } else {
+        res.json(data);
+      }
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  const handleSave = async (req: any, res: any, next: any, autosave = false) => {
+    try {
+      await service.saveAnnotation(req.params.imageId, req.body);
+      logger.info({ imageId: req.params.imageId, autosave, user: req.auth?.userId }, 'annotation saved');
+      res.status(204).send();
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  router.post('/:imageId', async (req, res, next) => {
+    await handleSave(req, res, next, false);
+  });
+
+  router.post('/:imageId/autosave', async (req, res, next) => {
+    await handleSave(req, res, next, true);
+  });
+
+  return router;
+};

--- a/server/src/routes/images.ts
+++ b/server/src/routes/images.ts
@@ -1,0 +1,55 @@
+import { Router } from 'express';
+import fs from 'fs';
+import mime from 'mime-types';
+import { AnnotationService } from '../services/annotationService';
+
+export const createImageRouter = (service: AnnotationService) => {
+  const router = Router();
+
+  router.get('/', async (req, res, next) => {
+    try {
+      const { cursor, limit } = req.query;
+      const result = await service.listImages(
+        typeof cursor === 'string' ? cursor : undefined,
+        limit ? Number(limit) : undefined
+      );
+      res.json({ items: result.items.map(({ path: _path, ...rest }) => rest), nextCursor: result.nextCursor });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get('/:id', async (req, res, next) => {
+    try {
+      const filePath = await service.getImagePath(req.params.id);
+      const stream = fs.createReadStream(filePath);
+      const stat = await fs.promises.stat(filePath);
+      const range = req.headers.range;
+      const contentType = mime.lookup(filePath) || 'application/octet-stream';
+      if (range) {
+        const [startStr, endStr] = range.replace(/bytes=/, '').split('-');
+        const start = Number(startStr);
+        const end = endStr ? Number(endStr) : stat.size - 1;
+        res.status(206);
+        res.set({
+          'Content-Range': `bytes ${start}-${end}/${stat.size}`,
+          'Accept-Ranges': 'bytes',
+          'Content-Length': end - start + 1,
+          'Content-Type': contentType,
+        });
+        fs.createReadStream(filePath, { start, end }).pipe(res);
+      } else {
+        res.set({
+          'Content-Length': stat.size,
+          'Content-Type': contentType,
+          'Cache-Control': 'private, max-age=60',
+        });
+        stream.pipe(res);
+      }
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  return router;
+};

--- a/server/src/services/annotationService.ts
+++ b/server/src/services/annotationService.ts
@@ -1,0 +1,24 @@
+import { StorageAdapter } from '../adapters/fsAdapter';
+
+export class AnnotationService {
+  constructor(private readonly storage: StorageAdapter) {}
+
+  async listImages(cursor?: string, limit?: number) {
+    return this.storage.listImages(cursor, limit);
+  }
+
+  async getImagePath(id: string) {
+    return this.storage.getImageStreamPath(id);
+  }
+
+  async getAnnotation(id: string) {
+    const raw = await this.storage.readAnnotation(id);
+    if (!raw) return null;
+    return JSON.parse(raw);
+  }
+
+  async saveAnnotation(id: string, payload: unknown) {
+    const body = JSON.stringify(payload, null, 2);
+    await this.storage.writeAnnotation(id, body);
+  }
+}

--- a/server/src/utils/logger.ts
+++ b/server/src/utils/logger.ts
@@ -1,0 +1,14 @@
+import pino from 'pino';
+
+const transport = pino.transport({
+  target: 'pino-pretty',
+  options: {
+    colorize: true,
+    translateTime: 'SYS:standard',
+  },
+});
+
+export const logger = pino({
+  level: process.env.NODE_ENV === 'production' ? 'info' : 'debug',
+  redact: ['req.headers.authorization', 'req.headers.cookie'],
+}, transport);

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- switch annotation storage and rendering to freehand polygons, auto-rejecting open or tiny strokes drawn on locked layers
- add undo/redo history, zoom reset, and a consolidated single-screen workspace with toast feedback and enhanced layer/shape panels
- refresh documentation to describe the freehand workflow and area metadata for CSV extraction
- clamp the Konva stage to the viewport so images stay centered and pannable without clipping on iPad Safari

## Testing
- not run (npm install blocked by registry policy in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e41d892df483279f4524c1edbf69b4